### PR TITLE
drivers: Replace calls to `spi_is_ready()` with `spi_is_ready_dt()`

### DIFF
--- a/drivers/sensor/paw3212/paw3212.c
+++ b/drivers/sensor/paw3212/paw3212.c
@@ -707,7 +707,7 @@ static int paw3212_init(const struct device *dev)
 	k_work_init(&data->trigger_handler_work, trigger_handler);
 	data->dev = dev;
 
-	if (!spi_is_ready(&config->bus)) {
+	if (!spi_is_ready_dt(&config->bus)) {
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/pmw3360/pmw3360.c
+++ b/drivers/sensor/pmw3360/pmw3360.c
@@ -826,7 +826,7 @@ static int pmw3360_init(const struct device *dev)
 	data->dev = dev;
 	k_work_init(&data->trigger_handler_work, trigger_handler);
 
-	if (!spi_is_ready(&config->bus)) {
+	if (!spi_is_ready_dt(&config->bus)) {
 		LOG_ERR("SPI device not ready");
 		return -ENODEV;
 	}

--- a/drivers/wifi/nrf700x/zephyr/src/qspi/src/spi_if.c
+++ b/drivers/wifi/nrf700x/zephyr/src/qspi/src/spi_if.c
@@ -213,7 +213,7 @@ unsigned int spim_cmd_sleep_rpu(void)
 
 int spim_init(struct qspi_config *config)
 {
-	if (!spi_is_ready(&spi_spec)) {
+	if (!spi_is_ready_dt(&spi_spec)) {
 		LOG_ERR("Device %s is not ready\n", spi_spec.bus->name);
 		return -ENODEV;
 	}


### PR DESCRIPTION
The former got deprecated in favor of the latter.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>