### PR TITLE
samples: zigbee: Fix building light switch multiprotocol

### DIFF
--- a/samples/zigbee/light_switch/sample.yaml
+++ b/samples/zigbee/light_switch/sample.yaml
@@ -32,7 +32,7 @@ tests:
     tags: ci_build smoke
   sample.zigbee.light_switch.fota_and_multiprotocol:
     build_only: true
-    extra_args: CONF_FILE=prj_fota.conf DOVERLAY_CONFIG=overlay-multiprotocol_ble.conf
+    extra_args: CONF_FILE=prj_fota.conf OVERLAY_CONFIG=overlay-multiprotocol_ble.conf
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
@@ -40,7 +40,7 @@ tests:
     tags: ci_build
   sample.zigbee.light_switch.multiprotocol:
     build_only: true
-    extra_args: DOVERLAY_CONFIG=overlay-multiprotocol_ble.conf
+    extra_args: OVERLAY_CONFIG=overlay-multiprotocol_ble.conf
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf52833dk_nrf52833


### PR DESCRIPTION
Fixed building light switch multiprotocol, changed DOVERLAY_CONFIG in sample.yaml to OVERLAY_CONFIG